### PR TITLE
corrección ejemplo R

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ library(readr)
 
 df<-read_csv('https://docs.google.com/spreadsheets/d/16SIYidLScgFZOeqpHmAo_u_rFmuxxpCCWeRAXSDOT3I/export?format=csv&id')
 ```
-Obs: Not sure if it works. Submit a PR if you find a way to do it.
 
 ### Stata
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ df = pd.read_csv(url)
 ```
 library(readr)
 
-df<-read.csv('https://docs.google.com/spreadsheets/d/16SIYidLScgFZOeqpHmAo_u_rFmuxxpCCWeRAXSDOT3I/export?format=csv&id')
+df<-read_csv('https://docs.google.com/spreadsheets/d/16SIYidLScgFZOeqpHmAo_u_rFmuxxpCCWeRAXSDOT3I/export?format=csv&id')
 ```
 Obs: Not sure if it works. Submit a PR if you find a way to do it.
 


### PR DESCRIPTION
si llaman al paquete readr deberían leer usando dicho paquete.

Es decir seria:

library(readr)
df<-read_csv("doc.csv")